### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,0 +1,49 @@
+name: Django CI
+
+on: [push, pull_request]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        services:
+            postgres:
+                image: postgres:latest
+                env:
+                    POSTGRES_USER: postgres
+                    POSTGRES_PASSWORD: postgres
+                    POSTGRES_DB: github_actions
+                    DB_PORT: "5432"
+                    DB_HOST: localhost
+                ports:
+                    - 5432:5432
+                options: --health-cmd pg_isready
+                    --health-interval 10s --health-timeout 5s --health-retries 5
+        steps:
+            - uses: actions/checkout@v3
+            - name: Set up Python 3.9
+              uses: actions/setup-python@v3
+              with:
+                  python-version: 3.9
+            - name: Active Python virtual enviroment
+              run: |
+                  python -m venv venv
+                  . venv/bin/activate
+            - name: Install Dependencies
+              run: python -m pip install --upgrade pip
+                  pip install -r requirements.txt
+            - name: Run Tests
+              env:
+                  DEBUG: True
+                  HOST_VAR: "http://localhost:8000"
+                  SECRET_KEY: "dummy"
+                  EMAIL_PASSWORD: "${{ secrets.EMAIL_PASSWORD }}"
+                  EMAIL_USER: "${{ secrets.EMAIL_USER }}"
+                  REDIS_URL: "${{ secrets.REDIS_URL }}"
+                  POSTGRES_USER: postgres
+                  POSTGRES_PASSWORD: postgres
+                  POSTGRES_DB: github_actions
+                  DB_PORT: "5432"
+                  DB_HOST: localhost
+              run: |
+                  python manage.py collectstatic
+                  pytest

--- a/memo/tests/test_card_list_api.py
+++ b/memo/tests/test_card_list_api.py
@@ -33,6 +33,10 @@ class CardListTest(APITestCase):
             "%Y-%m-%d %H:%M:%S"
         )
 
+        self.updated_at = datetime.datetime.astimezone(self.deck.updated_at).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+
     def test_created_two_decks(self):
         self.assertEqual(2, CardList.objects.count())
 
@@ -58,7 +62,7 @@ class CardListTest(APITestCase):
                     "description": self.deck2.description,
                     "cards": [],
                     "created_at": self.created_at,
-                    "updated_at": self.created_at,
+                    "updated_at": self.updated_at,
                     "active": self.deck2.active,
                 },
                 {
@@ -67,7 +71,7 @@ class CardListTest(APITestCase):
                     "description": self.deck.description,
                     "cards": [],
                     "created_at": self.created_at,
-                    "updated_at": self.created_at,
+                    "updated_at": self.updated_at,
                     "active": self.deck.active,
                 },
             ],


### PR DESCRIPTION
Issue: #5 

This Pull Request contains two changes in this project: 

- Add CI as suggested on issue #5 
- Update on test_card_list_apy.py, it was using created_at value twice on expected_data, causing an error on assertEqual when comparing the value of updated_at returned from the endpoint:
```

 expected_data = {
            "id": self.deck.id,
            "name": self.deck.name,
            "description": self.deck.description,
            "cards": [],
            "created_at": self.created_at,
            "updated_at": self.created_at,
            "active": True,
        }

 self.assertEqual(expected_data, response.data)
AssertionError: {'id'[183 chars]14:43:14', 'updated_at': '2022-07-06 14:43:14', 'active': True} != {'id'[183 chars]14:43:14', 'updated_at': '2022-07-06 14:43:15', 'active': True}
```