### PR TITLE
Add a new page with the user's performance report

### DIFF
--- a/memo/managers.py
+++ b/memo/managers.py
@@ -1,0 +1,96 @@
+import datetime
+from django.db import models
+from django.db.models import Count, Q, FloatField, Avg, Sum, Max
+from django.db.models.functions import Cast
+
+
+class CardManager(models.Manager):
+    def get_filter_by_deck(self, deck):
+        return (
+            super(CardManager, self)
+            .get_queryset()
+            .filter(deck_id=deck, card_answers__isnull=False)
+        )
+
+    def get_total_answer(self, deck):
+        return (
+            self.get_filter_by_deck(deck)
+            .annotate(total_answers=Count("card_answers"))
+            .aggregate(Sum("total_answers"))
+            .get("total_answers__sum")
+        )
+
+    def get_last_response(self, deck):
+        last_response = (
+            self.get_filter_by_deck(deck)
+            .annotate(last_response=Max("card_answers__updated_at"))
+            .aggregate(Max("last_response"))
+            .get("last_response__max")
+        )
+
+        if last_response != None:
+            last_response = datetime.datetime.astimezone(last_response).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+
+        return last_response
+
+    def get_card_with_highest_mistaken(self, deck):
+        return list(
+            self.get_filter_by_deck(deck)
+            .annotate(
+                highest_mistaken_percentage=Cast(
+                    Count("card_answers", filter=Q(card_answers__correct=False))
+                    * 100
+                    / Count("card_answers"),
+                    FloatField(),
+                )
+            )
+            .values_list("front", "highest_mistaken_percentage")
+            .exclude(highest_mistaken_percentage=0)
+            .order_by("-highest_mistaken_percentage")[:1]
+        )
+
+    def get_average_percentage_of_correct_answers(self, deck):
+        return (
+            self.filter(deck_id=deck, card_answers__isnull=False)
+            .annotate(
+                percent_of_correct_answers=Cast(
+                    Count("card_answers", filter=Q(card_answers__correct=True))
+                    * 100
+                    / Count("card_answers"),
+                    FloatField(),
+                ),
+            )
+            .aggregate(Avg("percent_of_correct_answers"))
+            .get("percent_of_correct_answers__avg")
+        )
+
+    def get_card_amount_in_deck(self, deck):
+        return len(self.filter(deck=deck))
+
+
+class DeckManager(models.Manager):
+    def get_my_learning_queryset(self, user):
+        from memo.models import Card
+
+        decks = self.filter(owner=user)
+        all_objects = []
+
+        for deck in decks:
+            all_objects.append(
+                {
+                    "deck_name": deck.name,
+                    "amount_of_cards": Card.objects.get_card_amount_in_deck(deck),
+                    "last_response": Card.objects.get_last_response(deck),
+                    "average_percentage_of_correct_answers": Card.objects.get_average_percentage_of_correct_answers(
+                        deck
+                    ),
+                    "total_deck_response": Card.objects.get_total_answer(deck),
+                    "card_with_highest_mistaken": Card.objects.get_card_with_highest_mistaken(
+                        deck
+                    ),
+                }
+            )
+
+        return all_objects

--- a/memo/managers.py
+++ b/memo/managers.py
@@ -28,7 +28,7 @@ class CardManager(models.Manager):
             .get("last_response__max")
         )
 
-        if last_response != None:
+        if last_response:
             last_response = datetime.datetime.astimezone(last_response).strftime(
                 "%Y-%m-%d %H:%M:%S"
             )
@@ -67,30 +67,9 @@ class CardManager(models.Manager):
         )
 
     def get_card_amount_in_deck(self, deck):
-        return len(self.filter(deck=deck))
+        return self.filter(deck=deck).count()
 
 
 class DeckManager(models.Manager):
-    def get_my_learning_queryset(self, user):
-        from memo.models import Card
-
-        decks = self.filter(owner=user)
-        all_objects = []
-
-        for deck in decks:
-            all_objects.append(
-                {
-                    "deck_name": deck.name,
-                    "amount_of_cards": Card.objects.get_card_amount_in_deck(deck),
-                    "last_response": Card.objects.get_last_response(deck),
-                    "average_percentage_of_correct_answers": Card.objects.get_average_percentage_of_correct_answers(
-                        deck
-                    ),
-                    "total_deck_response": Card.objects.get_total_answer(deck),
-                    "card_with_highest_mistaken": Card.objects.get_card_with_highest_mistaken(
-                        deck
-                    ),
-                }
-            )
-
-        return all_objects
+    def get_decks_by_owner(self, user):
+        return self.filter(owner=user)

--- a/memo/models.py
+++ b/memo/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.conf import settings
 from django.core.validators import MinLengthValidator
+from .managers import CardManager, DeckManager
 
 
 class Base(models.Model):
@@ -24,6 +25,8 @@ class Deck(Base):
     )
     description = models.TextField(verbose_name=("Description"), blank=True, default="")
 
+    objects = DeckManager()
+
     class Meta:
         verbose_name_plural = "Decks"
         verbose_name = "Deck"
@@ -36,6 +39,8 @@ class Card(Base):
     front = models.CharField(max_length=255, verbose_name=("Front"))
     back = models.CharField(max_length=255, verbose_name=("Back"))
     deck = models.ForeignKey(Deck, related_name="cards", on_delete=models.CASCADE)
+
+    objects = CardManager()
 
     class Meta:
         verbose_name_plural = "Cards"

--- a/memo/serializers.py
+++ b/memo/serializers.py
@@ -72,3 +72,39 @@ class PresetDeckSerializer(serializers.ModelSerializer):
             "created_at",
             "updated_at",
         )
+
+
+class MyLearningTableSerializer(serializers.ModelSerializer):
+
+    deck_name = serializers.CharField(source="name")
+    amount_of_cards = serializers.SerializerMethodField()
+    last_response = serializers.SerializerMethodField()
+    average_percentage_of_correct_answers = serializers.SerializerMethodField()
+    total_deck_response = serializers.SerializerMethodField()
+    card_with_highest_mistaken = serializers.SerializerMethodField()
+
+    def get_amount_of_cards(self, deck):
+        return Card.objects.get_card_amount_in_deck(deck)
+
+    def get_last_response(self, deck):
+        return Card.objects.get_last_response(deck)
+
+    def get_average_percentage_of_correct_answers(self, deck):
+        return Card.objects.get_average_percentage_of_correct_answers(deck)
+
+    def get_total_deck_response(self, deck):
+        return Card.objects.get_total_answer(deck)
+
+    def get_card_with_highest_mistaken(self, deck):
+        return Card.objects.get_card_with_highest_mistaken(deck)
+
+    class Meta:
+        model = Deck
+        fields = (
+            "deck_name",
+            "amount_of_cards",
+            "last_response",
+            "average_percentage_of_correct_answers",
+            "total_deck_response",
+            "card_with_highest_mistaken",
+        )

--- a/memo/tests/test_my_learning_api.py
+++ b/memo/tests/test_my_learning_api.py
@@ -1,0 +1,53 @@
+from django.contrib.auth import get_user_model
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+from rest_framework import status
+from decouple import config
+from model_bakery import baker
+from utils import convert_timestamp
+from memo.models import Card
+
+
+class MyLearningResultsTest(APITestCase):
+    def setUp(self):
+        self.User = get_user_model()
+        self.user = self.User.objects.create_superuser(
+            username="user", email="user@user.com", password="123"
+        )
+
+        token, created = Token.objects.get_or_create(user=self.user)
+        self.assertTrue(created)
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + token.key)
+        self.url = config("HOST_VAR") + "/api/my-learning-results/"
+
+        self.deck = baker.make("Deck", owner=self.user)
+        self.card = baker.make("Card", owner=self.user, deck=self.deck)
+        self.card_answer = baker.make(
+            "CardAnswerHistory", card=self.card, owner=self.user, correct=True
+        )
+        self.card_answer2 = baker.make(
+            "CardAnswerHistory", card=self.card, owner=self.user, correct=False
+        )
+        self.card2 = baker.make("Card", owner=self.user, deck=self.deck)
+
+    def test_get_my_learning_results(self):
+        response = self.client.get(self.url)
+
+        expected_data = [
+            {
+                "deck_name": self.deck.name,
+                "amount_of_cards": Card.objects.get_card_amount_in_deck(self.deck),
+                "last_response": convert_timestamp(self.card_answer2.created_at),
+                "average_percentage_of_correct_answers": Card.objects.get_average_percentage_of_correct_answers(
+                    self.deck
+                ),
+                "total_deck_response": Card.objects.get_total_answer(self.deck),
+                "card_with_highest_mistaken": Card.objects.get_card_with_highest_mistaken(
+                    self.deck
+                ),
+            }
+        ]
+
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(expected_data, response.data)

--- a/memo/urls.py
+++ b/memo/urls.py
@@ -6,6 +6,7 @@ from .views import (
     CardAnswersAPIView,
     PresetDecksAPIView,
     AddPresetDeckToUserDeckAPIView,
+    MyLearningTableAPIView,
 )
 from memo.views import DecksAPIView
 
@@ -18,7 +19,6 @@ app_name = "memo"
 urlpatterns = [
     path("cards/<int:pk>/", CardsAPIView.as_view(), name="card"),
     path("cards/", CardsAPIView.as_view(), name="cards"),
-    path("cards/", CardsAPIView.as_view(), name="cards"),
     path(
         "cards/<int:pk>/card_answer/", CardAnswersAPIView.as_view(), name="card_answers"
     ),
@@ -28,5 +28,10 @@ urlpatterns = [
         "preset_decks/<int:pk>/add_to_decks/",
         AddPresetDeckToUserDeckAPIView.as_view(),
         name="preset_deck_to_deck",
+    ),
+    path(
+        "my-learning-results/",
+        MyLearningTableAPIView.as_view(),
+        name="my_learning_result",
     ),
 ]

--- a/memo/views.py
+++ b/memo/views.py
@@ -8,6 +8,7 @@ from .serializers import (
     CardSerializer,
     CardAnswerHistorySerializer,
     PresetDeckSerializer,
+    MyLearningTableSerializer,
 )
 from rest_framework.pagination import PageNumberPagination
 
@@ -128,5 +129,6 @@ class AddPresetDeckToUserDeckAPIView(APIView):
 
 class MyLearningTableAPIView(APIView):
     def get(self, request):
-        my_learning = Deck.objects.get_my_learning_queryset(request.user)
-        return Response(my_learning, status=status.HTTP_200_OK)
+        my_learning = Deck.objects.get_decks_by_owner(request.user)
+        serialized_data = MyLearningTableSerializer(my_learning, many=True)
+        return Response(data=serialized_data.data, status=status.HTTP_200_OK)

--- a/memo/views.py
+++ b/memo/views.py
@@ -7,7 +7,6 @@ from .serializers import (
     DeckSerializer,
     CardSerializer,
     CardAnswerHistorySerializer,
-    PresetCardSerializer,
     PresetDeckSerializer,
 )
 from rest_framework.pagination import PageNumberPagination
@@ -125,3 +124,9 @@ class AddPresetDeckToUserDeckAPIView(APIView):
             return Response(status=status.HTTP_204_NO_CONTENT)
         except:
             return Response(status=status.HTTP_400_BAD_REQUEST)
+
+
+class MyLearningTableAPIView(APIView):
+    def get(self, request):
+        my_learning = Deck.objects.get_my_learning_queryset(request.user)
+        return Response(my_learning, status=status.HTTP_200_OK)

--- a/memo_front/views.py
+++ b/memo_front/views.py
@@ -22,6 +22,13 @@ def presets(request):
 
 
 @login_required(login_url="/accounts/login/")
+def my_learning(request):
+    html_template = loader.get_template("frontend/my-learning.html")
+    context = {"auth": request.user.auth_token}
+    return HttpResponse(html_template.render(context, request))
+
+
+@login_required(login_url="/accounts/login/")
 def deck(request, deck_id):
     html_template = loader.get_template("frontend/cards/index.html")
     context = {"deck_id": deck_id, "auth": request.user.auth_token}

--- a/project/urls.py
+++ b/project/urls.py
@@ -1,11 +1,17 @@
 from django.contrib import admin
 from django.urls import path, include
-from memo_front.views import redirect_if_not_logged, register_request, presets
+from memo_front.views import (
+    redirect_if_not_logged,
+    register_request,
+    presets,
+    my_learning,
+)
 from memo.urls import router
 
 urlpatterns = [
     path("", redirect_if_not_logged, name="index"),
     path("presets/", presets, name="presets"),
+    path("my-learning/", my_learning, name="my_learning"),
     path("accounts/", include("django.contrib.auth.urls")),
     path("acounts/register/", register_request, name="register"),
     path("admin/", admin.site.urls),

--- a/templates/frontend/base.html
+++ b/templates/frontend/base.html
@@ -11,9 +11,13 @@
     <title>Memo</title>
     <link rel="icon" type="image/x-icon" href="{% static 'img/favicon.ico' %}">
   </head>
+  
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.12.1/css/jquery.dataTables.min.css">
   <link rel="stylesheet" href="{% static 'css/global.css' %}">
   <link rel="stylesheet" href="{% static 'css/assigment.css' %}">
+
+
   <body>
       <div id="loadingPage" class="center-spinner">
         <div class="spinner-border" role="status">
@@ -31,6 +35,9 @@
                   </li>
                   <li class="nav-item active">
                       <a class="nav-link" href="{% url 'presets' %}">Preset Decks</a>
+                  </li>
+                  <li class="nav-item active">
+                      <a class="nav-link" href="{% url 'my_learning' %}">My Learning</a>
                   </li>
                   <li class="nav-item">
                       <a class="nav-link" href="#"></a>
@@ -82,6 +89,7 @@
     <script src="https://code.jquery.com/jquery-3.6.0.min.js" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.min.js" integrity="sha384-VHvPCCyXqtD5DqJeNxl2dtTyhF78xXNXdkwX1CZeRusQfRKp+tA7hAShOK/B/fQ2" crossorigin="anonymous"></script>
+    <script src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.min.js" crossorigin="anonymous"></script>
     <script>
       localStorage.setItem("auth",'{{ auth }}')
       let authToken = localStorage.getItem("auth");

--- a/templates/frontend/my-learning.html
+++ b/templates/frontend/my-learning.html
@@ -16,7 +16,7 @@
                         <th>Last Response</th>
                         <th>Average % of correct</th>
                         <th>Total deck's response</th>
-                        <th>Card with the highest mistaken percentage</th>
+                        <th>Card with the highest mistaken %</th>
                     </tr>
                 </thead>
                 <tbody id="tableData">
@@ -40,7 +40,6 @@
     }
 
   const requestGetRequestTable = () => {
-
     $.ajax({
       url: "/api/my-learning-results/",
       type: "GET",
@@ -65,22 +64,22 @@
 }
 
 const tableTemplate = (deck) => {
-      highestMistaken = (deck.cardsWithHighestMistaken.length === 0) ?
-      '-' : deck.cardsWithHighestMistaken[0].front 
-      + ' - ' + deck.cardsWithHighestMistaken[0].highest_mistaken + '%';
+      highestMistaken = (deck.card_with_highest_mistaken.length === 0) ?
+      '-' : deck.card_with_highest_mistaken[0].front 
+      + ' (' + deck.card_with_highest_mistaken[0].highest_mistaken_percentage + '%' + ')';
 
-      averagePercentageOfCorrect = (deck.averagePercentageOfCorrect === null) ? 
-      '-' : deck.averagePercentageOfCorrect + '%';
+      averagePercentageOfCorrectAnswers = (deck.average_percentage_of_correct_answers === null) ? 
+      '-' : deck.average_percentage_of_correct_answers + '%';
 
-      amountOfCards = (!deck.amountOfCards) ? 
-      ' - ' : deck.amountOfCards;
+      amountOfCards = (!deck.amount_of_cards) ? 
+      ' - ' : deck.amount_of_cards;
 
       return `<tr> 
-        <td>${deck.deckName}</td>
+        <td>${deck.deck_name}</td>
         <td>${amountOfCards}</td>
-        <td>${deck.lastResponseDay ?? '-'}</td>
-        <td>${averagePercentageOfCorrect}</td>
-        <td>${deck.totalDecksResponse ?? '-'}</td>
+        <td>${deck.last_response ?? '-'}</td>
+        <td>${averagePercentageOfCorrectAnswers}</td>
+        <td>${deck.total_deck_response ?? '-'}</td>
         <td>${highestMistaken}</td>
         </tr>`
   }

--- a/templates/frontend/my-learning.html
+++ b/templates/frontend/my-learning.html
@@ -8,15 +8,15 @@
                 <div id="legend"></div>
             </div>
           </div>
-              <table id="table" class="display" >
+              <table id="table" class="display">
                 <thead>
                     <tr>
                         <th>Name</th>
                         <th>Cards</th>
-                        <th>Last Response</th>
-                        <th>Average % of correct</th>
                         <th>Total deck's response</th>
+                        <th>Average % of correct response</th>
                         <th>Card with the highest mistaken %</th>
+                        <th>Last Response</th>
                     </tr>
                 </thead>
                 <tbody id="tableData">
@@ -64,23 +64,26 @@
 }
 
 const tableTemplate = (deck) => {
-      highestMistaken = (deck.card_with_highest_mistaken.length === 0) ?
-      '-' : deck.card_with_highest_mistaken[0].front 
-      + ' (' + deck.card_with_highest_mistaken[0].highest_mistaken_percentage + '%' + ')';
-
+      if(deck.card_with_highest_mistaken.length === 0){
+        highestMistaken = '-'
+      }else{
+        card = deck.card_with_highest_mistaken[0]
+        highestMistaken = card[0] + ' (' + card[1] + '%) ';
+      }
+      
       averagePercentageOfCorrectAnswers = (deck.average_percentage_of_correct_answers === null) ? 
       '-' : deck.average_percentage_of_correct_answers + '%';
 
       amountOfCards = (!deck.amount_of_cards) ? 
       ' - ' : deck.amount_of_cards;
-
+      console.log(deck.card_with_highest_mistaken[0])
       return `<tr> 
         <td>${deck.deck_name}</td>
         <td>${amountOfCards}</td>
-        <td>${deck.last_response ?? '-'}</td>
-        <td>${averagePercentageOfCorrectAnswers}</td>
         <td>${deck.total_deck_response ?? '-'}</td>
+        <td>${averagePercentageOfCorrectAnswers}</td>
         <td>${highestMistaken}</td>
+        <td>${deck.last_response ?? '-'}</td>
         </tr>`
   }
 

--- a/templates/frontend/my-learning.html
+++ b/templates/frontend/my-learning.html
@@ -1,0 +1,90 @@
+{% extends 'frontend/base.html' %} 
+{% block content %}
+<div class="container">
+    <div class="jumbotron">
+        <div class="row align-items-center" style="padding-bottom:30px;">
+            <div class="col-md-6">
+              <h1>My learning</h1>
+                <div id="legend"></div>
+            </div>
+          </div>
+              <table id="table" class="display" >
+                <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Cards</th>
+                        <th>Last Response</th>
+                        <th>Average % of correct</th>
+                        <th>Total deck's response</th>
+                        <th>Card with the highest mistaken percentage</th>
+                    </tr>
+                </thead>
+                <tbody id="tableData">
+                </tbody>
+            </table>
+      </div>
+    </div>
+</div>
+{% endblock content %} 
+{% block js %}
+<script>
+  let presetDeckData = [];
+
+    $(document).ready(function () {
+      loadPage();
+    });
+  
+    const loadPage = () => {
+      let authToken = localStorage.getItem("auth");
+      requestGetRequestTable();
+    }
+
+  const requestGetRequestTable = () => {
+
+    $.ajax({
+      url: "/api/my-learning-results/",
+      type: "GET",
+      beforeSend: function(request) {
+        request.setRequestHeader("Authorization", "Token " + authToken);
+      },
+      dataType: "json",
+      success: function (data) {
+
+        if(data.length > 0){
+          for (let index = 0; index < data.length; index++){
+            $("#tableData").append(tableTemplate(data[index]));
+          }
+        }
+
+      },
+      complete: function(){
+        $('#table').DataTable();
+        mainPageLoad();
+      }
+    });
+}
+
+const tableTemplate = (deck) => {
+      highestMistaken = (deck.cardsWithHighestMistaken.length === 0) ?
+      '-' : deck.cardsWithHighestMistaken[0].front 
+      + ' - ' + deck.cardsWithHighestMistaken[0].highest_mistaken + '%';
+
+      averagePercentageOfCorrect = (deck.averagePercentageOfCorrect === null) ? 
+      '-' : deck.averagePercentageOfCorrect + '%';
+
+      amountOfCards = (!deck.amountOfCards) ? 
+      ' - ' : deck.amountOfCards;
+
+      return `<tr> 
+        <td>${deck.deckName}</td>
+        <td>${amountOfCards}</td>
+        <td>${deck.lastResponseDay ?? '-'}</td>
+        <td>${averagePercentageOfCorrect}</td>
+        <td>${deck.totalDecksResponse ?? '-'}</td>
+        <td>${highestMistaken}</td>
+        </tr>`
+  }
+
+</script>
+{% endblock js %}
+


### PR DESCRIPTION
Issue: #9

This Pull Request contains a new feature and minor fix in this project:

# Adjustments:
* Removed unused import in `memo/views.py`.

# Add/New: 
* Added two new managers and created a new file: `managers.py.` It contains `DeckManager` and `CardManager` that will provide data to the `my-learning-results` endpoint.

* Created a new endpoint: GET: `my-learning-results/` It will return the data below: 

```
    {
        "deck_name": "",
        "amount_of_cards": 0,
        "last_response": null,
        "average_percentage_of_correct_answers": null,
        "total_deck_response": null,
        "card_with_highest_mistaken": []
    }
```

* Created a new page: `/my-learning` using the html file `my-learning.html` and added a new  `My Learning` menu option on the head nav bar. The data table uses [this library](https://datatables.net/) to populate and display the data. 

Last response in descending order:
![Screenshot from 2022-07-26 17-24-05](https://user-images.githubusercontent.com/42613997/181105943-6526ec39-b73c-4cfd-8357-d7f98b5aeb51.png)

Card with highest mistaken % descending order:
![Screenshot from 2022-07-26 17-23-59](https://user-images.githubusercontent.com/42613997/181105948-bef8ea90-fb05-44cd-a210-e5eef1f7c96a.png)

Average of correct % descending order:
![Screenshot from 2022-07-26 17-23-52](https://user-images.githubusercontent.com/42613997/181105951-b19a52ef-8f42-413b-8030-5e23ce2855c9.png)

Cards length descending order:
![Screenshot from 2022-07-26 17-23-35](https://user-images.githubusercontent.com/42613997/181105952-4dbaf6e3-eff4-44ac-89b2-d3f7cf735d7e.png)

# Tests
* Add test related to new `my-learning-result` endpoint.

